### PR TITLE
ファイル・ライブラリのロードに関連する箇所の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in bbiff.gemspec
 gemspec
+
+gem 'bundler', require: ['net/http', 'uri', 'cgi', 'shellwords']
+gem 'activesupport', require: ['active_support', 'active_support/core_ext/numeric']

--- a/bin/bbiff
+++ b/bin/bbiff
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+
+$LOAD_PATH.unshift File.expand_path( '../../lib', __FILE__)
+
 require 'bbiff'
 
-# load '/usr/local/lib/bbiff/bbiff.rb'
+main

--- a/lib/bbiff.rb
+++ b/lib/bbiff.rb
@@ -1,6 +1,8 @@
-require 'shellwords'
-require_relative 'bbiff/bbs_reader'
-require_relative 'bbiff/res_format'
+require 'bundler'
+Bundler.require :default
+
+require 'bbiff/bbs_reader'
+require 'bbiff/res_format'
 
 def parse_range(str)
   if str == "all"
@@ -55,5 +57,3 @@ def main
   start_no = ARGV[1] ? ARGV[1].to_i : thread.last + 1
   start_polling(thread, start_no)
 end
-
-main

--- a/lib/bbiff.rb
+++ b/lib/bbiff.rb
@@ -53,7 +53,7 @@ def main
     sure = $3.to_i
   end
 
-  thread = Bbs::C板.new(*ita).thread(sure)    
+  thread = Bbs::C板.new(*ita).thread(sure)
   start_no = ARGV[1] ? ARGV[1].to_i : thread.last + 1
   start_polling(thread, start_no)
 end

--- a/lib/bbiff/bbs_reader.rb
+++ b/lib/bbiff/bbs_reader.rb
@@ -1,6 +1,3 @@
-require 'net/http'
-require 'uri'
-
 module Bbs
 
 class C板

--- a/lib/bbiff/res_format.rb
+++ b/lib/bbiff/res_format.rb
@@ -1,8 +1,3 @@
-require 'cgi'
-require 'active_support'
-require 'active_support/core_ext'
-require_relative 'bbs_reader'
-
 class Fixnum
   def em
     ' ' * (self*2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
 require 'bbiff'


### PR DESCRIPTION
- Bundlerでrequireするようにした
  - 関連するgemを`Bundler.require`で読み込むように変更した
  - ActiveSupportで、`active_support/core_ext/numeric`のみ読み込むように変更した
- `lib/bbiff.rb`で呼ばれている`main`を、テストなどしやすいように`bin/bbiff`で呼ぶように変更した
- 不要なスペースの削除
